### PR TITLE
Don't enforce linting errors when listing releases

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,4 +3,5 @@ export default {
   localPath: process.env.STUDIO_YAML_DIR || "./replicated",
   upstreamEndpoint: process.env.STUDIO_UPSTREAM_BASE_URL || "https://api.replicated.com/market/",
   lintThreshold: process.env.STUDIO_LINT_THRESHOLD || "error",
+  lintRequired: process.env.STUDIO_LINT_REQUIRED === "true",
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,5 +3,5 @@ export default {
   localPath: process.env.STUDIO_YAML_DIR || "./replicated",
   upstreamEndpoint: process.env.STUDIO_UPSTREAM_BASE_URL || "https://api.replicated.com/market/",
   lintThreshold: process.env.STUDIO_LINT_THRESHOLD || "error",
-  lintRequired: process.env.STUDIO_LINT_REQUIRED === "true",
+  lintRequired: /^(?:y|yes|true|1)$/i.test(process.env.STUDIO_LINT_REQUIRED || ""),
 };

--- a/src/handlers/getAppUpgrades.ts
+++ b/src/handlers/getAppUpgrades.ts
@@ -58,7 +58,9 @@ export default async function (req) {
         linterErrors,
       );
       failedPaths.push(releasePath);
-      return;
+      if (consts.lintRequired) {
+        return;
+      }
     }
 
     versions.push(releaseDetails(release, yamlContents, lastModifiedTime));
@@ -66,7 +68,11 @@ export default async function (req) {
 
   if (!_.isEmpty(failedPaths)) {
     console.log();
-    console.log(chalk.yellow("One or more releases were not included in the release list because they failed linting."));
+    if (consts.lintRequired) {
+      console.log(chalk.yellow("One or more releases were not included in the release list because they failed linting."));
+    } else {
+      console.log(chalk.yellow("One or more releases has failed linting."));
+    }
     console.log(chalk.yellow("Please correct the errors in"));
     console.log(chalk.yellow("  * " + failedPaths.join("\n  * ")));
   }


### PR DESCRIPTION
By default no longer skip releases that fail lint. Optionally add an env var that will enable legacy behavior.